### PR TITLE
feat: 채팅 화면에 판매 정보 불러오도록

### DIFF
--- a/client/src/components/views/ChattingPage/ChatList.jsx
+++ b/client/src/components/views/ChattingPage/ChatList.jsx
@@ -15,7 +15,7 @@ function ChatList() {
   const [exchangeRates, setExchangeRates] = useState({});
 
   const statusColors = {
-    "판매중": "#CA2F28",
+    "판매중": "#1E62C1",
     "거래중": "#0BB770",
     "거래완료": "#1F2024"
   };

--- a/client/src/components/views/PostListPage/PostList.jsx
+++ b/client/src/components/views/PostListPage/PostList.jsx
@@ -345,6 +345,7 @@ useEffect(() => {
                 ) : (
                   <NoImage>이미지 없음</NoImage>
                 )}
+                {sell.status === "판매중" && <ReservedLabel color="#1E62C1">판매중</ReservedLabel>}
                 {sell.status === "거래중" && <ReservedLabel color="#0BB770">거래중</ReservedLabel>}
                 {sell.status === "거래완료" && <ReservedLabel color="black">거래완료</ReservedLabel>}
               </ImageContainer>

--- a/server/routes/sellRoutes.js
+++ b/server/routes/sellRoutes.js
@@ -107,6 +107,7 @@ router.get("/sellDescription/:sellId", async (req, res) => {
         ? userProfile.profile_img
         : "https://via.placeholder.com/40"; // 기본 이미지
     const reformatSell = (sell) => ({
+      sellId: sell._id,
       ...sell.toObject(),
       profile_img: profileImage, //기본 이미지 설정
       images: sell.images.map(

--- a/server/services/chatService.js
+++ b/server/services/chatService.js
@@ -16,6 +16,7 @@ const createChatRoom = async(sellId, sellerId, buyerId) => {
     //새로운 채팅방 생성
     const newChatRoom = new ChatRoom({
         chatRoomId: sellId,
+        sellId: sellId, 
         seller: {
             userId: sellerId,
         },
@@ -47,7 +48,7 @@ const getChatList = async(userId) => {
         })
         .populate({
             path: "chatRoomId",
-            select: "status amount currency"
+            select: "status amount currency _id"
         })
         .populate({
             path: "seller.userId buyer.userId",
@@ -60,6 +61,7 @@ const getChatList = async(userId) => {
             const isSeller = chatRoom.seller.userId._id.toString() === userId.toString();
             return {
                 chatRoomId: chatRoom.chatRoomId._id,
+                sellId: chatRoom.chatRoomId._id,  
                 status: chatRoom.chatRoomId?.status,
                 amount: chatRoom.chatRoomId?.amount,
                 currency: chatRoom.chatRoomId?.currency,
@@ -74,7 +76,7 @@ const getChatList = async(userId) => {
     }
 };
 
-//chatRoodId로 판매자 구매자 id가져오기
+//chatRoomId로 판매자 구매자 id가져오기
 const getChatters = async(chatRoomId) => {
     try{
         const chatRoom = await ChatRoom.findOne({ chatRoomId });
@@ -125,7 +127,7 @@ const getSellerInfo = async(chatRoomId) => {
         const sellerId = chatRoom.seller.userId;
         const sellerInfo = await User.findById(sellerId);
 
-        console.log("채팅 구매자 정보 확인", buyerInfo);
+        console.log("채팅 구매자 정보 확인", sellerInfo);
         return sellerInfo;
     }catch(error){
         console.error("Error getting sellerInfo", error);


### PR DESCRIPTION
## 🔘Part

- [x] FE
- [ ] BE
- [ ] AI

  <br/>


## 🔎 작업 내용

- 채팅 화면에 판매글의 사진, 통화, 금액, 실시간 원화 불러오도록
- 위의 것을 클릭 시 판매상세의 넘어가도록
- opponent api로 변경
  <br/>


## 🔧 앞으로의 과제

- 프론트 UI 수정, 반응형, 잘리는 부분 수정

  <br/>


## ➕ 논의 혹은 전달 사항

- 

<br/>
